### PR TITLE
Fix for EOL problems with patch.exe

### DIFF
--- a/macros.cmake
+++ b/macros.cmake
@@ -224,6 +224,7 @@ MACRO ( OPENMS_PATCH patchfile_varname workingdir_varname patchedfile_varname)
 
       # logfile
       file(APPEND ${LOGFILE} "${PATCH_OUT}\n\r")
+    endif()
         
     if (NOT PATCH_SUCCESS EQUAL 0)
       message(STATUS "Patching ${${patchedfile_varname}} ... failed (with and without --binary option)")

--- a/macros.cmake
+++ b/macros.cmake
@@ -221,8 +221,9 @@ MACRO ( OPENMS_PATCH patchfile_varname workingdir_varname patchedfile_varname)
         ARGS ${PATCH_ARGUMENTS} "\"${${patchfile_varname}}\""
         OUTPUT_VARIABLE PATCH_OUT
         RETURN_VALUE PATCH_SUCCESS)
-    
-    file(APPEND ${LOGFILE} "${PATCH_OUT}\n\r")
+
+      # logfile
+      file(APPEND ${LOGFILE} "${PATCH_OUT}\n\r")
         
     if (NOT PATCH_SUCCESS EQUAL 0)
       message(STATUS "Patching ${${patchedfile_varname}} ... failed (with and without --binary option)")


### PR DESCRIPTION
Fixes problem of OS (version) and patch.exe specific problems where the --binary flag results in failure of patch.exe.
Solution: Try with --binary option first, then without. Should therefore be "backwards" compatible.