### PR TITLE
[Hotfix] [skip ci] Hosting the sources on the FTP Server of FU

### DIFF
--- a/macros.cmake
+++ b/macros.cmake
@@ -69,7 +69,7 @@ endmacro()
 ## @param libname The libary that should be downloaded
 macro(download_contrib_archive libname)
   # constant
-  set(_BASE_URL "http://github.com/OpenMS/contrib-sources/raw/master/")
+  set(_BASE_URL "http://ftp.mi.fu-berlin.de/pub/OpenMS/contrib-sources/")
 
   # the files/folders where downloads are stored
   set(_archive_folder "${PROJECT_BINARY_DIR}/archives")

--- a/macros.cmake
+++ b/macros.cmake
@@ -69,6 +69,8 @@ endmacro()
 ## @param libname The libary that should be downloaded
 macro(download_contrib_archive libname)
   # constant
+  # Currently this points to an FTP at FU Berlin
+  # Sources are checked out regularly from OpenMS/contrib-sources via a cron job
   set(_BASE_URL "http://ftp.mi.fu-berlin.de/pub/OpenMS/contrib-sources/")
 
   # the files/folders where downloads are stored


### PR DESCRIPTION
Git LFS was a bad idea, due to limited bandwidth. For maximum compatibility (SF fails in some CMake versions because of redirects) I put the contrib on our FTP.
Disadvantage:
Not everybody can change it easily.
