### PR TITLE
Feature: fix coin build

### DIFF
--- a/libraries.cmake/coinor.cmake
+++ b/libraries.cmake/coinor.cmake
@@ -95,6 +95,10 @@ MACRO( OPENMS_CONTRIB_BUILD_COINOR)
     set(PATCH_FILE "${PROJECT_SOURCE_DIR}/patches/coinor/CoinUtils.configure.diff")
     set(PATCHED_FILE "${COINOR_DIR}/CoinUtils/configure")
     OPENMS_PATCH( PATCH_FILE COINOR_DIR PATCHED_FILE)
+
+    set(PATCH_FILE "${PROJECT_SOURCE_DIR}/patches/coinor/Clp.configure.diff")
+    set(PATCHED_FILE "${COINOR_DIR}/Clp/configure")
+    OPENMS_PATCH( PATCH_FILE COINOR_DIR PATCHED_FILE)
   
     # configure -- 
     if( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )

--- a/libraries.cmake/coinor.cmake
+++ b/libraries.cmake/coinor.cmake
@@ -91,6 +91,10 @@ MACRO( OPENMS_CONTRIB_BUILD_COINOR)
     # set(PATCH_FILE "${PROJECT_SOURCE_DIR}/patches/coinor/MakefileCoinMP.in.diff")
     # set(PATCHED_FILE "${COINOR_DIR}/CoinMP/Makefile.in")
     # OPENMS_PATCH( PATCH_FILE COINOR_DIR PATCHED_FILE)  
+
+    set(PATCH_FILE "${PROJECT_SOURCE_DIR}/patches/coinor/CoinUtils.configure.diff")
+    set(PATCHED_FILE "${COINOR_DIR}/CoinUtils/configure")
+    OPENMS_PATCH( PATCH_FILE COINOR_DIR PATCHED_FILE)
   
     # configure -- 
     if( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )

--- a/patches/coinor/Clp.configure.diff
+++ b/patches/coinor/Clp.configure.diff
@@ -1,0 +1,20 @@
+--- Clp/configure.bck	2017-10-13 20:10:54.733967079 -0400
++++ Clp/configure	2017-10-13 20:11:06.613987770 -0400
+@@ -2887,7 +2887,7 @@
+           *-darwin*)
+             ;;
+           *)
+-            coin_warn_cflags="-pedantic-errors $coin_warn_cflags"
++            coin_warn_cflags=" $coin_warn_cflags"
+             ;;
+         esac
+     esac
+@@ -3756,7 +3756,7 @@
+           *-darwin*)
+             ;;
+           *)
+-            coin_warn_cxxflags="-pedantic-errors $coin_warn_cxxflags"
++            coin_warn_cxxflags=" $coin_warn_cxxflags"
+             ;;
+         esac
+     esac

--- a/patches/coinor/CoinUtils.configure.diff
+++ b/patches/coinor/CoinUtils.configure.diff
@@ -1,0 +1,20 @@
+--- CoinUtils/configure	2017-10-13 17:30:08.291283980 -0400
++++ CoinUtils/configure	2017-10-13 17:29:48.259229890 -0400
+@@ -2883,7 +2883,7 @@
+           *-darwin*)
+             ;;
+           *)
+-            coin_warn_cflags="-pedantic-errors $coin_warn_cflags"
++            coin_warn_cflags=" $coin_warn_cflags"
+             ;;
+         esac
+     esac
+@@ -3752,7 +3752,7 @@
+           *-darwin*)
+             ;;
+           *)
+-            coin_warn_cxxflags="-pedantic-errors $coin_warn_cxxflags"
++            coin_warn_cxxflags=" $coin_warn_cxxflags"
+             ;;
+         esac
+     esac


### PR DESCRIPTION
fixes #46 by being less pedantic and removing `-pedantic-errors`. This helps on some systems, most notable the CentOS system I am working on.