### PR TITLE
Windows: check consistency of cl.exe and Generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ endif()
 PROJECT("OpenMS_CONTRIB")
 
 # Heart of the BUILD system : only edit when you know what you are doing (we don't)
-# quick manual for most commands: http://www.cmake.org/cmake/help/cmake2.6docs.html
+# quick manual for most commands: https://cmake.org/cmake/help/v3.3/manual/cmake-commands.7.html
 # useful predefined variables: http://www.paraview.org/Wiki/CMake_Useful_Variables
 
 # force cmake > 3.1 to force enable c11 support
@@ -272,7 +272,7 @@ if (CMAKE_SIZEOF_VOID_P MATCHES "8")
 else()
   set(CONTRIB_ADDRESSMODEL 32 CACHE INTERNAL "Architecture-bits")
 endif()
-message(STATUS "ADDRESSMODEL IS: ${CONTRIB_ADDRESSMODEL} bit")
+message(STATUS "ADDRESSMODEL is: ${CONTRIB_ADDRESSMODEL}-bit")
 if (NOT CONTRIB_ADDRESSMODEL MATCHES "32|64")
   Message(FATAL_ERROR "CONTRIB_ADDRESSMODEL is neither 32 nor 64! Please correct this!")
 endif()
@@ -281,6 +281,25 @@ endif()
 set(LOGFILE "${PROJECT_BINARY_DIR}/contrib_build.log")
 
 if (MSVC)
+  
+  ## check that the console environment has a cl.exe architecture which is identical to the VS Generator
+  ## If cl.exe builds 32-bit libs and VS Generator is Win64, we'd end up with mixed 32bit/64bit libraries, depending on how each lib is build (Cmake, bjam, nmake)
+  execute_process(COMMAND "cl.exe" OUTPUT_VARIABLE cl_out ERROR_VARIABLE cl_out)
+  ##message(STATUS "Cl.exe said: ${cl_out}")
+  if (cl_out MATCHES ".*x64.*")
+    message(STATUS "Cl.exe produces: 64-bit")
+    set(CL_ADDRESSMODEL 64)
+  elseif (cl_out MATCHES ".*x86.*")
+    message(STATUS "Cl.exe produces: 32-bit")
+    set(CL_ADDRESSMODEL 32)
+  else()
+    message(FATAL_ERROR "Could not determine if cl.exe builds x86 or x64 apps. Make sure cl.exe is available in your environment!")
+  endif()
+  if (NOT (CL_ADDRESSMODEL EQUAL CONTRIB_ADDRESSMODEL))
+    message(FATAL_ERROR "cl.exe (${CL_ADDRESSMODEL}-bit) and Visual Studio Generator (${CONTRIB_ADDRESSMODEL}-bit) do not match. Please fix your PATH environment to find the proper cl.exe or use/omit the Win64 generator.")
+  endif()
+
+
   ## guess MSVC Version (we need this in order to correctly guess the names of the VS solution targets.
   ## Since CMake 3.0 you can use the years (e.g. 2013) for every VS version. For VS 8 and 9 you have to use the year!
   if (CMAKE_GENERATOR MATCHES ".*Visual Studio 8 2005.*")

--- a/macros.cmake
+++ b/macros.cmake
@@ -32,9 +32,11 @@
 # $Authors: Stephan Aiche, Chris Bielow $
 # --------------------------------------------------------------------------
 
+
+
 macro(determine_compiler_version )
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR  "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
+    execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
                     OUTPUT_VARIABLE CXX_COMPILER_VERSION)
     string(REGEX MATCHALL "[0-9]+" CXX_COMPILER_COMPONENTS ${CXX_COMPILER_VERSION})
     list(GET CXX_COMPILER_COMPONENTS 0 CXX_COMPILER_VERSION_MAJOR)
@@ -49,7 +51,7 @@ macro(determine_compiler_version )
 endmacro()
 
 ## validates the archive for the given library
-## @param libname The libary that should be validate
+## @param libname The libary that should be validated
 macro(validate_archive libname)
   set(_archive_folder "${PROJECT_BINARY_DIR}/archives")
   set(_target_file "${_archive_folder}/${ARCHIVE_${libname}}")
@@ -77,7 +79,7 @@ endmacro()
 
 
 ## downloads the archive for the given library
-## @param libname The libary that should be downloaded
+## @param libname The library that should be downloaded
 macro(download_contrib_archive libname)
   # constant
   # Currently this points to an FTP at FU Berlin


### PR DESCRIPTION
fix #74 

produces an error message like
```
c:\dev\contrib_build>cmake .
-- ADDRESSMODEL is: 64-bit
-- Cl.exe produces: 32-bit
CMake Error at CMakeLists.txt:299 (message):
  cl.exe (32-bit) and Visual Studio Generator (64-bit) do not match.  Please
  fix your PATH environment to find the proper cl.exe or use/omit the Win64
  generator.
```
if the console is not 64 bit.