### PR TITLE
[FIX] debug libs for hdf5

### DIFF
--- a/libraries.cmake/hdf5.cmake
+++ b/libraries.cmake/hdf5.cmake
@@ -86,5 +86,26 @@ MACRO( OPENMS_CONTRIB_BUILD_HDF5 )
     message(STATUS "Building HDF5 library (Release) .. done")
   endif()
 
+  # we also want the debug lib on windows
+  if(MSVC)
+    # build debug
+    message(STATUS "Building HDF5 library (Debug) .. ")
+    execute_process(COMMAND ${CMAKE_COMMAND} --build ${_HDF5_NATIVE_BUILD_DIR} --target ${_HDF5_INSTALL_TARGET} --config Debug
+                            WORKING_DIRECTORY ${_HDF5_NATIVE_BUILD_DIR}
+                            OUTPUT_VARIABLE _HDF5_BUILD_OUT
+                            ERROR_VARIABLE _HDF5_BUILD_ERR
+                            RESULT_VARIABLE _HDF5_BUILD_SUCCESS)
+
+    # output to logfile
+    file(APPEND ${LOGFILE} ${_HDF5_BUILD_OUT})
+    file(APPEND ${LOGFILE} ${_HDF5_BUILD_ERR})
+
+    if (NOT _HDF5_BUILD_SUCCESS EQUAL 0)
+      message(FATAL_ERROR "Building HDF5 library (Debug) .. failed")
+    else()
+      message(STATUS "Building HDF5 library (Debug) .. done")
+    endif()
+  endif()
+
 ENDMACRO( OPENMS_CONTRIB_BUILD_HDF5 )
 


### PR DESCRIPTION
this produces

```
C:\openms\builds\test_hdf5_debug4>dir lib
 Volume in drive C is OS
 Volume Serial Number is 7CAE-3E08

 Directory of C:\openms\builds\test_hdf5_debug4\lib

2019-05-14  10:08 AM    <DIR>          .
2019-05-14  10:08 AM    <DIR>          ..
2019-05-14  10:08 AM        10,395,048 libhdf5.lib
2019-05-14  10:05 AM             2,944 libhdf5.settings
2019-05-14  10:08 AM         2,357,018 libhdf5_cpp.lib
2019-05-14  10:08 AM         8,220,854 libhdf5_cpp_D.lib
2019-05-14  10:08 AM        37,180,462 libhdf5_D.lib
2019-05-14  10:08 AM           306,448 libhdf5_hl.lib
2019-05-14  10:08 AM            15,916 libhdf5_hl_cpp.lib
2019-05-14  10:08 AM            33,826 libhdf5_hl_cpp_D.lib
2019-05-14  10:08 AM           466,300 libhdf5_hl_D.lib
2019-05-14  10:06 AM    <DIR>          pkgconfig
               9 File(s)     58,978,816 bytes
               3 Dir(s)  30,499,667,968 bytes free
```