### PR TITLE
fix handling of free slacks

### DIFF
--- a/libraries.cmake/coinor.cmake
+++ b/libraries.cmake/coinor.cmake
@@ -14,6 +14,10 @@ MACRO( OPENMS_CONTRIB_BUILD_COINOR)
   endif()
   OPENMS_SMARTEXTRACT(ZIP_ARGS ARCHIVE_COINOR "COINOR" "AUTHORS")
 
+  set(PATCH_FILE "${PROJECT_SOURCE_DIR}/patches/coinor/Idiot.cpp.diff")
+  set(PATCHED_FILE "${COINOR_DIR}/Clp/src/Idiot.cpp")
+  OPENMS_PATCH( PATCH_FILE COINOR_DIR PATCHED_FILE)
+  
   if (MSVC)
 		## changes made to COIN-MP solution files (for all 6 libs):
 		## - in Properties -> Librarian -> OutputFile: output lib in debug mode X64 (!!!) from $(OutDir)\$(ProjectName).lib to $(OutDir)\$(ProjectName)d.lib

--- a/patches/coinor/Idiot.cpp.diff
+++ b/patches/coinor/Idiot.cpp.diff
@@ -1,0 +1,18 @@
+--- Clp/src/Idiot.cpp
++++ Clp/src/Idiot.cpp
+@@ -2016,7 +2016,6 @@ Idiot::crossOver(int mode)
+ 		     }
+ 		   }
+ 		 }
+-		 delete [] which;
+ 		 for (int i = 0; i < nrows; i++) {
+ 		   if (rowIsBasic[i]>=0) {
+ 		     model_->setRowStatus(i, ClpSimplex::basic);
+@@ -2038,6 +2037,7 @@ Idiot::crossOver(int mode)
+ 		     model_->setColumnStatus(i,ClpSimplex::superBasic);
+ 		   }
+ 		 }
++		 delete[] which;
+ 	       }
+           }
+           if (model_) {


### PR DESCRIPTION

applying Clp fix Revision: d3a7c5989868ca1c9536841690518e6fbf2b8d0f
Author: John Forrest <john.forrest@fastercoin.com>
Date: 2/12/2016 11:03:24 AM
Message:
fix handling of free slacks

----
Modified: Clp/src/Idiot.cpp

----

we are facing random crashes with the following call stack
 0xC0000005: Access violation reading location 0x000001ED858275E0.
OpenMSd.dll!Idiot::crossOver(int)
OpenMSd.dll!Idiot::crash(int,class CoinMessageHandler *,class CoinMessages const *,bool)
OpenMSd.dll!ClpSimplex::initialSolve(class ClpSolve &)
OpenMSd.dll!OsiClpSolverInterface::initialSolve(void)
OpenMSd.dll!CbcModel::initialSolve(void)
OpenMSd.dll!OpenMS::LPWrapper::solve(OpenMS::LPWrapper::SolverParam & __formal, const unsigned __int64 verbose_level) Line 592
OpenMSd.dll!OpenMS::MRMFeatureSelectorQMIP::optimize(const std::vector<std::pair<double,OpenMS::String>,std::allocator<std::pair<double,OpenMS::String>>> & time_to_name, const std::map<OpenMS::String,std::vector<OpenMS::Feature,std::allocator<OpenMS::Feature>>,std::less<OpenMS::String>,std::allocator<std::pair<OpenMS::String const ,std::vector<OpenMS::Feature,std::allocator<OpenMS::Feature>>>>> & feature_name_map, std::vector<OpenMS::String,std::allocator<OpenMS::String>> & result, const OpenMS::MRMFeatureSelector::SelectorParameters & parameters) Line 243
OpenMSd.dll!OpenMS::MRMFeatureSelector::selectMRMFeature(const OpenMS::FeatureMap & features, OpenMS::FeatureMap & selected_filtered, const OpenMS::MRMFeatureSelector::SelectorParameters & parameters) Line 336
OpenMSd.dll!OpenMS::MRMBatchFeatureSelector::batchMRMFeatures(const OpenMS::MRMFeatureSelector & feature_selector, const OpenMS::FeatureMap & features, OpenMS::FeatureMap & selected_features, const std::vector<OpenMS::MRMFeatureSelector::SelectorParameters,std::allocator<OpenMS::MRMFeatureSelector::SelectorParameters>> & parameters) Line 53
OpenMSd.dll!OpenMS::MRMBatchFeatureSelector::batchMRMFeaturesQMIP(const OpenMS::FeatureMap & features, OpenMS::FeatureMap & selected_features, const std::vector<OpenMS::MRMFeatureSelector::SelectorParameters,std::allocator<OpenMS::MRMFeatureSelector::SelectorParameters>> & parameters) Line 64

It appears that an array (```which```) is deleted just before the the use of another array, ```rawIsBasic```, which is actually a pointer to inside the ```which``` array.:

```
int * columnIsBasic=which+ncols;
int * rowIsBasic=columnIsBasic+ncols;
```

```
delete [] which;
for (int i = 0; i < nrows; i++) {
	if (rowIsBasic[i]>=0) {
		 model_->setRowStatus(i, ClpSimplex::basic);
	} else if (rowlower[i]==rowupper[i]) {
		 model_->setRowStatus(i, ClpSimplex::isFixed);
	} else if (rowsol[i]-rowlower[i]<rowupper[i]-rowsol[i]) {
		 model_->setRowStatus(i, ClpSimplex::atLowerBound);
	} else {
		 model_->setRowStatus(i, ClpSimplex::atUpperBound);
	}
}
```
this leads to random crashes.

This fix has been applied in Clp library on 2/12/2016, and we may need it.

