### PR TITLE
[ADD] openmp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: contrib
-      
+
     - name: Install prerequisites
       shell: bash
       run: |
@@ -38,7 +38,7 @@ jobs:
               echo "$RUNNER_OS not supported"
               exit 1
          fi
-         
+
     # TODO cmake should be new enough now
     #- name: Installing cmake (only linux support)
     #  run: |
@@ -47,20 +47,21 @@ jobs:
     #      curl -sSL -O https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz
     #      sudo tar zxf cmake-3.15.3-Linux-x86_64.tar.gz -C $GITHUB_WORKSPACE/cmake
     #      echo ::set-env PATH=$GITHUB_WORKSPACE/cmake/bin:$PATH
-      
+
     # https://github.com/marketplace/actions/visual-studio-shell
     - name: Set up Visual Studio shell
       uses: egor-tensin/vs-shell@v2
       with:
         arch: x64
-      
+
     # TODO use appropriate number of cores
     - name: Build contrib
       run: |
            mkdir contrib-build
            cd contrib-build
            cmake ${{matrix.CMAKE_ARGS}} -DBUILD_TYPE=ALL -DNUMBER_OF_JOBS=4 ../contrib
-           
+           cmake ${{matrix.CMAKE_ARGS}} -DBUILD_TYPE=OPENMP -DNUMBER_OF_JOBS=4 ../contrib
+
     # TODO hope that they finally release a decent uploading action.
     - name: Clean build
       shell: bash
@@ -70,7 +71,7 @@ jobs:
            rm -rf src
            rm -rf CMakeFiles
            find . -maxdepth 1 -type f -not -name 'contrib_build.log' -delete
-           
+
     #TODO switch to V2 once it is released (this is to only upload relevant folders)
     - uses: actions/upload-artifact@v1
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,8 @@
 ##       - however: exec_process seems to handle our arguments incorrectly (at least on Windows). Check functionality before you commit!
 
 # Determine what to build (all or single library)
-set( BUILD_TYPE LIST CACHE STRING "Can be used to restrict building to a single library: ALL,LIBSVM,XERCESC,BOOST,GSL,COINOR,BZIP2,ZLIB,GLPK,KISSFFT")
-set( VALID_BUILD_TYPES "ALL" "LIBSVM" "XERCESC" "BOOST" "COINOR" "BZIP2" "ZLIB" "GLPK" "EIGEN" "WILDMAGIC" "SQLITE" "KISSFFT" "HDF5")
+set( BUILD_TYPE LIST CACHE STRING "Can be used to restrict building to a single library: ALL,LIBSVM,XERCESC,BOOST,GSL,COINOR,BZIP2,ZLIB,GLPK,KISSFFT,OPENMP")
+set( VALID_BUILD_TYPES "ALL" "LIBSVM" "XERCESC" "BOOST" "COINOR" "BZIP2" "ZLIB" "GLPK" "EIGEN" "WILDMAGIC" "SQLITE" "KISSFFT" "HDF5" "OPENMP")
 
 # check build type
 if (BUILD_TYPE STREQUAL "HELP" OR BUILD_TYPE STREQUAL "LIST")
@@ -198,11 +198,11 @@ set(WILDMAGIC_DIR ${CONTRIB_BIN_SOURCE_DIR}/WildMagic5)
 set(KISSFFT_DIR ${CONTRIB_BIN_SOURCE_DIR}/kissfft)
 set(SQLITE_DIR ${CONTRIB_BIN_SOURCE_DIR}/sqlite-autoconf-3150000)
 set(HDF5_DIR ${CONTRIB_BIN_SOURCE_DIR}/hdf5-1.10.5)
-
+set(OPENMP_DIR ${CONTRIB_BIN_SOURCE_DIR}/openmp-12.0.1.src)
 
 ## source(archive) paths
 ## PLEASE upload all source archives to
-##     http://ftp.mi.fu-berlin.de/pub/OpenMS/contrib-sources/
+##     https://abibuilder.informatik.uni-tuebingen.de/archive/openms/contrib/source_packages/
 ## and provide the necessary information below
 ##  ARCHIVE_<LIBNAME> the name of the archive as it was uploaded
 ##  ARCHIVE_<LIBNAME>_TAR the name of the tar in the tar.gz
@@ -278,6 +278,10 @@ set(ARCHIVE_HDF5 hdf5-1.10.5.tar.gz)
 set(ARCHIVE_HDF5_TAR hdf5-1.10.5.tar)
 set(ARCHIVE_HDF5_SHA1 "541bdf33b1a9676a8340db958a277993a4193189")
 
+set(ARCHIVE_OPENMP openmp-12.0.1.src.tar.xz)
+set(ARCHIVE_OPENMP_tar openmp-12.0.1.src.tar)
+set(ARCHIVE_OPENMP_SHA1 "7c051f6050ff23763b253a757927774b5eeaf644")
+
 ## necessary for clean up .. change if install process of library changes
 set(INCLUDE_DIR_BOOST ${CONTRIB_BIN_INCLUDE_DIR}/boost)
 set(INCLUDE_DIR_XERCES ${CONTRIB_BIN_INCLUDE_DIR}/xercesc)
@@ -286,6 +290,7 @@ set(INCLUDE_DIR_COINOR ${CONTRIB_BIN_INCLUDE_DIR}/coin)
 set(INCLUDE_DIR_EIGEN ${CONTRIB_BIN_INCLUDE_DIR}/eigen3)
 set(INCLUDE_DIR_WILDMAGIC ${CONTRIB_BIN_INCLUDE_DIR}/WildMagic5)
 set(INCLUDE_DIR_KISSFFT ${CONTRIB_BIN_INCLUDE_DIR}/kissfft)
+set(INCLUDE_DIR_OPENMP ${CONTRIB_BIN_INCLUDE_DIR}/openmp.src)
 
 ## hack for simple libs that do not have include directories
 set(INCLUDE_FILES_LIBSVM ${CONTRIB_BIN_INCLUDE_DIR}/svm.h)
@@ -493,6 +498,7 @@ include ("${CMAKE_SOURCE_DIR}/libraries.cmake/wildmagic.cmake")
 include ("${CMAKE_SOURCE_DIR}/libraries.cmake/kissfft.cmake")
 include ("${CMAKE_SOURCE_DIR}/libraries.cmake/sqlite.cmake")
 include ("${CMAKE_SOURCE_DIR}/libraries.cmake/hdf5.cmake")
+include ("${CMAKE_SOURCE_DIR}/libraries.cmake/openmp.cmake")
 
 ## build mac os x specific C/C++ flags
 set( OPENMS_CONTRIB_MACOSX_MIXED_MODE 0 CACHE INTERNAL "building multiple architectures on MacOSX" FORCE)
@@ -627,10 +633,23 @@ if (BUILD_TYPE STREQUAL "ALL" OR BUILD_TYPE STREQUAL "SQLITE")
   OPENMS_COPY_LIBS("SQLITE")
 endif()
 
+##################################################
+###       HDF5                                 ###
+##################################################
+
 if (BUILD_TYPE STREQUAL "ALL" OR BUILD_TYPE STREQUAL "HDF5")
   OPENMS_CLEAN_LIB("HDF5")
   OPENMS_CONTRIB_BUILD_HDF5()
   OPENMS_COPY_LIBS("HDF5")
+endif()
+
+##################################################
+###       OPENMP                               ###
+##################################################
+if (BUILD_TYPE STREQUAL "OPENMP")
+  OPENMS_CLEAN_LIB("OPENMP")
+  OPENMS_CONTRIB_BUILD_OPENMP()
+  OPENMS_COPY_LIBS("OPENMP")
 endif()
 
 ## finally copy README.txt to project-binary directory to mark process complete

--- a/libraries.cmake/openmp.cmake
+++ b/libraries.cmake/openmp.cmake
@@ -1,0 +1,123 @@
+##################################################
+###       OPENMP                               ###
+##################################################
+
+MACRO( OPENMS_CONTRIB_BUILD_OPENMP )
+OPENMS_LOGHEADER_LIBRARY("libomp")
+# extract: (takes very long.. so skip if possible)
+if(MSVC)
+  set(ZIP_ARGS "x -y -osrc")
+else()
+  set(ZIP_ARGS "xzf")
+endif()
+OPENMS_SMARTEXTRACT(ZIP_ARGS ARCHIVE_OPENMP "OPENMP" "README")
+
+if (MSVC)
+  message(STATUS "Generating openmp build system .. ")
+  execute_process(COMMAND ${CMAKE_COMMAND}
+                          -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBRARIES}
+                          -D INSTALL_BIN_DIR=${PROJECT_BINARY_DIR}/lib
+                          -G "${CMAKE_GENERATOR}"
+                          ${ARCHITECTURE_OPTION_CMAKE}
+                          -D CMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}
+                          ${OPENMP_EXTRA_CMAKE_FLAG}
+                          .
+                  WORKING_DIRECTORY ${OPENMP_DIR}
+                  OUTPUT_VARIABLE OPENMP_CMAKE_OUT
+                  ERROR_VARIABLE OPENMP_CMAKE_ERR
+                  RESULT_VARIABLE OPENMP_CMAKE_SUCCESS)
+
+  # output to logfile
+  file(APPEND ${LOGFILE} ${OPENMP_CMAKE_OUT})
+  file(APPEND ${LOGFILE} ${OPENMP_CMAKE_ERR})
+
+  if(NOT OPENMP_CMAKE_SUCCESS EQUAL 0)
+    message(FATAL_ERROR "Generating libomp build system .. failed")
+  else()
+    message(STATUS "Generating libomp build system .. done")
+  endif()
+
+  message(STATUS "Building libomp (Debug) .. ")
+  execute_process(COMMAND ${CMAKE_COMMAND} --build ${OPENMP_DIR} --target INSTALL --config Debug
+                  WORKING_DIRECTORY ${OPENMP_DIR}
+                  OUTPUT_VARIABLE OPENMP_BUILD_OUT
+                  ERROR_VARIABLE OPENMP_BUILD_ERR
+                  RESULT_VARIABLE OPENMP_BUILD_SUCCESS)
+
+  # output to logfile
+  file(APPEND ${LOGFILE} ${OPENMP_BUILD_OUT})
+  file(APPEND ${LOGFILE} ${OPENMP_BUILD_ERR})
+
+  if(NOT OPENMP_BUILD_SUCCESS EQUAL 0)
+    message(FATAL_ERROR "Building libomp (Debug) .. failed")
+  else()
+    message(STATUS "Building libomp (Debug) .. done")
+  endif()
+
+  # rebuild as release
+  message(STATUS "Building libomp (Release) .. ")
+  execute_process(COMMAND ${CMAKE_COMMAND} --build ${OPENMP_DIR} --target INSTALL --config Release
+                  WORKING_DIRECTORY ${OPENMP_DIR}
+                  OUTPUT_VARIABLE OPENMP_BUILD_OUT
+                  ERROR_VARIABLE OPENMP_BUILD_ERR
+                  RESULT_VARIABLE OPENMP_BUILD_SUCCESS)
+  # output to logfile
+  file(APPEND ${LOGFILE} ${OPENMP_BUILD_OUT})
+  file(APPEND ${LOGFILE} ${OPENMP_BUILD_ERR})
+
+  if(NOT OPENMP_BUILD_SUCCESS EQUAL 0)
+    message(FATAL_ERROR "Building libomp lib (Release) .. failed")
+  else()
+    message(STATUS "Building libomp lib (Release) .. done")
+  endif()
+
+else()
+  if (APPLE)
+    set(_OPENMP_CMAKE_ARGS
+        "-DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}"
+        "-DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}"
+        "-DCMAKE_MACOSX_RPATH=TRUE"
+       )
+  else()
+    set(_OPENMP_CMAKE_ARGS "")
+  endif()
+
+  # CFLAGS for openmp compiler
+  set(OPENMP_CFLAGS "-Wall -O3 -fPIC")
+
+  message(STATUS "Generating libomp build system .. ")
+  execute_process(COMMAND ${CMAKE_COMMAND}
+                          ${_OPENMP_CMAKE_ARGS}
+                          -G "${CMAKE_GENERATOR}"
+                          -D CMAKE_BUILD_TYPE=Release
+                          -D CMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}
+                          -D CMAKE_C_FLAGS=${OPENMP_CFLAGS}
+                          .
+                  WORKING_DIRECTORY ${OPENMP_DIR}
+                  OUTPUT_VARIABLE OPENMP_CMAKE_OUT
+                  ERROR_VARIABLE OPENMP_CMAKE_ERR
+                  RESULT_VARIABLE OPENMP_CMAKE_SUCCESS)
+
+  # rebuild as release
+  message(STATUS "Building libomp (Release) .. ")
+  execute_process(COMMAND ${CMAKE_COMMAND}
+                  --build ${OPENMP_DIR}
+                  --target install
+                  WORKING_DIRECTORY ${OPENMP_DIR}
+                  OUTPUT_VARIABLE OPENMP_BUILD_OUT
+                  ERROR_VARIABLE OPENMP_BUILD_ERR
+                  RESULT_VARIABLE OPENMP_BUILD_SUCCESS)
+
+  # output to logfile
+  file(APPEND ${LOGFILE} ${OPENMP_BUILD_OUT})
+  file(APPEND ${LOGFILE} ${OPENMP_BUILD_ERR})
+
+  if(NOT OPENMP_BUILD_SUCCESS EQUAL 0)
+    message(FATAL_ERROR "Building libomp (Release) .. failed")
+  else()
+    message(STATUS "Building libomp (Release) .. done")
+  endif()
+
+endif()
+
+ENDMACRO( OPENMS_CONTRIB_BUILD_OPENMP )

--- a/libraries.cmake/openmp.cmake
+++ b/libraries.cmake/openmp.cmake
@@ -8,7 +8,7 @@ OPENMS_LOGHEADER_LIBRARY("libomp")
 if(MSVC)
   set(ZIP_ARGS "x -y -osrc")
 else()
-  set(ZIP_ARGS "xzf")
+  set(ZIP_ARGS "xJf")
 endif()
 OPENMS_SMARTEXTRACT(ZIP_ARGS ARCHIVE_OPENMP "OPENMP" "README")
 

--- a/libraries.cmake/openmp.cmake
+++ b/libraries.cmake/openmp.cmake
@@ -12,9 +12,18 @@ else()
 endif()
 OPENMS_SMARTEXTRACT(ZIP_ARGS ARCHIVE_OPENMP "OPENMP" "README")
 
+# see https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/libomp.rb
+# Disable LIBOMP_INSTALL_ALIASES, otherwise the library is installed as
+# libgomp alias which can conflict with GCC's libgomp.
+set(_GENERAL_OPENMP_CMAKE_ARGS
+    "-DLIBOMP_INSTALL_ALIASES=OFF"
+    "-DLIBOMP_ENABLE_SHARED=OFF"
+    )
+
 if (MSVC)
   message(STATUS "Generating openmp build system .. ")
   execute_process(COMMAND ${CMAKE_COMMAND}
+                          ${_GENERAL_OPENMP_CMAKE_ARGS}
                           -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBRARIES}
                           -D INSTALL_BIN_DIR=${PROJECT_BINARY_DIR}/lib
                           -G "${CMAKE_GENERATOR}"
@@ -27,40 +36,16 @@ if (MSVC)
                   ERROR_VARIABLE OPENMP_CMAKE_ERR
                   RESULT_VARIABLE OPENMP_CMAKE_SUCCESS)
 
-  # output to logfile
-  file(APPEND ${LOGFILE} ${OPENMP_CMAKE_OUT})
-  file(APPEND ${LOGFILE} ${OPENMP_CMAKE_ERR})
-
-  if(NOT OPENMP_CMAKE_SUCCESS EQUAL 0)
-    message(FATAL_ERROR "Generating libomp build system .. failed")
-  else()
-    message(STATUS "Generating libomp build system .. done")
-  endif()
-
-  message(STATUS "Building libomp (Debug) .. ")
-  execute_process(COMMAND ${CMAKE_COMMAND} --build ${OPENMP_DIR} --target INSTALL --config Debug
-                  WORKING_DIRECTORY ${OPENMP_DIR}
-                  OUTPUT_VARIABLE OPENMP_BUILD_OUT
-                  ERROR_VARIABLE OPENMP_BUILD_ERR
-                  RESULT_VARIABLE OPENMP_BUILD_SUCCESS)
-
-  # output to logfile
-  file(APPEND ${LOGFILE} ${OPENMP_BUILD_OUT})
-  file(APPEND ${LOGFILE} ${OPENMP_BUILD_ERR})
-
-  if(NOT OPENMP_BUILD_SUCCESS EQUAL 0)
-    message(FATAL_ERROR "Building libomp (Debug) .. failed")
-  else()
-    message(STATUS "Building libomp (Debug) .. done")
-  endif()
-
-  # rebuild as release
+  # build libomp
   message(STATUS "Building libomp (Release) .. ")
-  execute_process(COMMAND ${CMAKE_COMMAND} --build ${OPENMP_DIR} --target INSTALL --config Release
+  execute_process(COMMAND ${CMAKE_COMMAND}
+                  --build ${OPENMP_DIR}
+                  --target INSTALL
                   WORKING_DIRECTORY ${OPENMP_DIR}
                   OUTPUT_VARIABLE OPENMP_BUILD_OUT
                   ERROR_VARIABLE OPENMP_BUILD_ERR
                   RESULT_VARIABLE OPENMP_BUILD_SUCCESS)
+
   # output to logfile
   file(APPEND ${LOGFILE} ${OPENMP_BUILD_OUT})
   file(APPEND ${LOGFILE} ${OPENMP_BUILD_ERR})
@@ -87,6 +72,7 @@ else()
 
   message(STATUS "Generating libomp build system .. ")
   execute_process(COMMAND ${CMAKE_COMMAND}
+                          ${_GENERAL_OPENMP_CMAKE_ARGS}
                           ${_OPENMP_CMAKE_ARGS}
                           -G "${CMAKE_GENERATOR}"
                           -D CMAKE_BUILD_TYPE=Release

--- a/macros.cmake
+++ b/macros.cmake
@@ -79,9 +79,9 @@ endmacro()
 ## @param libname The library that should be downloaded
 macro(download_contrib_archive libname)
   # constant
-  # Currently this points to an FTP at FU Berlin
+  # Currently this points to the OpenMS build archive
   # Sources are checked out regularly from OpenMS/contrib-sources via a cron job
-  set(_BASE_URL "http://ftp.mi.fu-berlin.de/pub/OpenMS/contrib-sources/")
+  set(_BASE_URL "https://abibuilder.informatik.uni-tuebingen.de/archive/openms/contrib/source_packages/")
 
   # the files/folders where downloads are stored
   set(_archive_folder "${PROJECT_BINARY_DIR}/archives")
@@ -136,7 +136,6 @@ macro(download_contrib_archive libname)
     message(STATUS "Downloading ${libname} .. skipped (already downloaded)")
   endif(NOT EXISTS ${_target_file})
 endmacro()
-
 
 ## extract archive to PROJECT_BINARY_DIR
 ## Warning: it is important that ${${libname}_DIR} exists!


### PR DESCRIPTION
Add the compilation of OpenMP (libomp), which gives the possibility to compile with a set `OSX_DEPLOYMENT_TARGET`.

Change the source_package directory to link to the abibuilder instead of the FU Berlin FTP.

OpenMP is currently excluded from the "ALL" build option. 
