### PR TITLE
Update hdf5.cmake to enable h5diff

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -44,9 +44,9 @@ WORKDIR /
 
 # Metadata
 LABEL base.image="ubuntu:22.04"
-LABEL version="3.0"
+LABEL version="3.1"
 LABEL software="OpenMS (dependencies)"
-LABEL software.version="3.0.0-Ubuntu22.04"
+LABEL software.version="3.1.0-Ubuntu22.04"
 LABEL description="Baseimage to build OpenMS: C++ libraries and tools for MS/MS data analysis"
 LABEL website="http://www.openms.org/"
 LABEL documentation="http://www.openms.org/"

--- a/libraries.cmake/hdf5.cmake
+++ b/libraries.cmake/hdf5.cmake
@@ -45,7 +45,7 @@ MACRO( OPENMS_CONTRIB_BUILD_HDF5 )
                         -D CMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}
                         -D BUILD_TESTING=Off
                         -D HDF5_BUILD_EXAMPLES=Off
-                        -D HDF5_BUILD_TOOLS=Off
+                        -D HDF5_BUILD_TOOLS=On
                         ${_HDF5_CMAKE_ARGS}
                         ${HDF5_DIR}
                         WORKING_DIRECTORY ${_HDF5_NATIVE_BUILD_DIR}


### PR DESCRIPTION
needed if we want to use the hdf5-config.cmake files.
See discussion at https://github.com/OpenMS/OpenMS/pull/6713