### PR TITLE
add manual contrib release step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:  # This allows you to manually trigger the workflow from the GitHub UI
 
 jobs:
   build:
@@ -66,8 +68,34 @@ jobs:
            rm -rf CMakeFiles
            find . -maxdepth 1 -type f -not -name 'contrib_build.log' -delete
 
-    #TODO switch to V2 once it is released (this is to only upload relevant folders)
-    - uses: actions/upload-artifact@v3
+    - name: Configure Git for Tagging
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        git config --global user.name 'GitHub Actions'
+        git config --global user.email 'actions@github.com'
+
+    - name: Create and Push Tag
+      if: github.event_name == 'workflow_dispatch'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        TAG_NAME="release-$(date +'%Y%m%d%H%M%S')"
+        echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV  # Save the tag name to an environment variable
+        git tag $TAG_NAME
+        git push origin $TAG_NAME
+
+    - name: Create Release
+      if: github.event_name == 'workflow_dispatch'
+      id: create_release
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ env.TAG_NAME }}  # Explicitly specify the tag name for the release
+        files:
+          ./contrib-build/contrib_build-${{runner.os}}.tar.gz
+
+    - uses: actions/upload-artifact@v4
       with:
         name: contrib-build-${{runner.os}}
         path: contrib-build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,7 @@ jobs:
           ./contrib-build/contrib_build-${{runner.os}}.tar.gz
 
     - uses: actions/upload-artifact@v4
+      if: github.event_name == 'workflow_dispatch'
       with:
         name: contrib-build-${{runner.os}}
         path: contrib-build


### PR DESCRIPTION
Key idea here is, as long as we use the contrib on e.g. windows, enable a simple way to get built artefacts and use them in the OpenMS/OpenMS or other actions. Right now, we rely on jenkins and the buildarchive here. This complicates things a lot as the contrib e.g. needs to be built for different visual studio versions (see https://abibuilder.cs.uni-tuebingen.de/archive/openms/contrib/windows/x64/).

Things I am unsure:
- how to select a proper tag that allows us to download and use the contrib.tar.gz from the OpenMS/OpenMS actions?