### PR TITLE
Add numeric_conversion option to Boost configuration

### DIFF
--- a/libraries.cmake/boost.cmake
+++ b/libraries.cmake/boost.cmake
@@ -154,8 +154,8 @@ MACRO( OPENMS_CONTRIB_BUILD_BOOST)
     endif()
 
     # bootstrap boost
-    message(STATUS "Bootstrapping Boost libraries (./bootstrap.sh --prefix=${PROJECT_BINARY_DIR} --with-toolset=${_boost_bootstrap_toolchain} --with-libraries=date_time,iostreams,math,regex,system,thread) ...")
-    execute_process(COMMAND ./bootstrap.sh --prefix=${PROJECT_BINARY_DIR} --with-libraries=iostreams,math,date_time,regex,system,thread
+    message(STATUS "Bootstrapping Boost libraries (./bootstrap.sh --prefix=${PROJECT_BINARY_DIR} --with-toolset=${_boost_bootstrap_toolchain} --with-libraries=date_time,iostreams,math,regex,system,thread,numeric_conversion) ...")
+    execute_process(COMMAND ./bootstrap.sh --prefix=${PROJECT_BINARY_DIR} --with-libraries=iostreams,math,date_time,regex,system,thread,numeric_conversion
                     WORKING_DIRECTORY ${BOOST_DIR}
                     OUTPUT_VARIABLE BOOST_BOOTSTRAP_OUT
                     ERROR_VARIABLE BOOST_BOOTSTRAP_OUT
@@ -164,10 +164,10 @@ MACRO( OPENMS_CONTRIB_BUILD_BOOST)
     # logfile
     file(APPEND ${LOGFILE} ${BOOST_BOOTSTRAP_OUT})
     if (NOT BOOST_BOOTSTRAP_SUCCESS EQUAL 0)
-      message(STATUS "Bootstrapping Boost libraries (./bootstrap.sh --prefix=${PROJECT_BINARY_DIR} --with-libraries=iostreams,math,date_time,regex,system,thread) ... failed")
+      message(STATUS "Bootstrapping Boost libraries (./bootstrap.sh --prefix=${PROJECT_BINARY_DIR} --with-libraries=iostreams,math,date_time,regex,system,thread,numeric_conversion) ... failed")
       message(FATAL_ERROR ${BOOST_BOOTSTRAPPING_OUT})
     else()
-      message(STATUS "Bootstrapping Boost libraries (./bootstrap.sh --prefix=${PROJECT_BINARY_DIR} --with-libraries=iostreams,math,date_time,regex,system,thread) ... done")
+      message(STATUS "Bootstrapping Boost libraries (./bootstrap.sh --prefix=${PROJECT_BINARY_DIR} --with-libraries=iostreams,math,date_time,regex,system,thread,numeric_conversion) ... done")
     endif()
 
 


### PR DESCRIPTION
It's required for arrow build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include the Boost numeric_conversion component across Windows, Linux, and macOS toolchains; related build messages and installer steps were updated to reflect the expanded library list.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->