### PR TITLE
fix: bundle Arrow deps to fix build on Debian 12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,12 +59,12 @@ jobs:
         shell: bash
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get -y install make autoconf automake tar patch libtool gcc libthrift-dev 
+            sudo apt-get -y install make autoconf automake tar patch libtool gcc
           elif [ "$RUNNER_OS" == "Windows" ]; then
             # choco install important_windows_software
             echo "Nothing to install"
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            brew install autoconf automake libtool thrift
+            brew install autoconf automake libtool
           else
             echo "$RUNNER_OS not supported"
             exit 1

--- a/libraries.cmake/arrow.cmake
+++ b/libraries.cmake/arrow.cmake
@@ -13,6 +13,12 @@ else()
 endif()
 OPENMS_SMARTEXTRACT(ZIP_ARGS ARCHIVE_ARROW "ARROW" "README")
 
+## Arrow dependencies not built by the contrib (Snappy, zstd, Thrift, xsimd, RapidJSON)
+## are fetched and built as bundled dependencies by Arrow's own build system.
+## This avoids requiring these as system packages (fixes build on e.g. Debian 12).
+## Dependencies already provided by contrib (zlib, bzip2, boost) are found via CMAKE_PREFIX_PATH.
+## Note: building Arrow requires internet access for the bundled dependency downloads.
+
 ## build the obj/lib
 if (MSVC)
   set(ARROW_CXXFLAGS "/I${PROJECT_BINARY_DIR}/include")
@@ -36,6 +42,11 @@ if (MSVC)
                           -D ARROW_WITH_BZIP2=ON
                           -D ARROW_WITH_ZSTD=ON
                           -D ARROW_WITH_SNAPPY=ON
+                          -D Snappy_SOURCE=BUNDLED
+                          -D zstd_SOURCE=BUNDLED
+                          -D Thrift_SOURCE=BUNDLED
+                          -D xsimd_SOURCE=BUNDLED
+                          -D RapidJSON_SOURCE=BUNDLED
                           .
                   WORKING_DIRECTORY ${ARROW_DIR}
                   OUTPUT_VARIABLE ARROW_CMAKE_OUT
@@ -136,6 +147,11 @@ else() ## Linux/MacOS
                           "-DARROW_WITH_BZIP2=ON"
                           "-DARROW_WITH_ZSTD=ON"
                           "-DARROW_WITH_SNAPPY=ON"
+                          "-DSnappy_SOURCE=BUNDLED"
+                          "-Dzstd_SOURCE=BUNDLED"
+                          "-DThrift_SOURCE=BUNDLED"
+                          "-Dxsimd_SOURCE=BUNDLED"
+                          "-DRapidJSON_SOURCE=BUNDLED"
                           .
                   WORKING_DIRECTORY ${ARROW_DIR}
                   OUTPUT_VARIABLE ARROW_CMAKE_OUT


### PR DESCRIPTION
## Summary

- Bundle Arrow's missing dependencies (Snappy, zstd, Thrift, xsimd, RapidJSON) using Arrow's per-dependency `_SOURCE=BUNDLED` mechanism instead of requiring them as system packages
- Remove `libthrift-dev` / `thrift` from CI prerequisites since Thrift is now bundled
- Add documentation comment explaining the bundled dependency strategy

## Context

Arrow from contrib does not build on Debian 12 (and likely other minimal Linux installations) because it requires Snappy, zstd, Thrift, xsimd, and RapidJSON which are not built by the contrib system and are not available as system packages.

Previously, the CI worked around this by installing `libthrift-dev` (Ubuntu) and `thrift` (macOS), and relied on GitHub runners having other deps pre-installed. This is fragile and undocumented.

The fix uses Arrow's built-in `<pkg>_SOURCE=BUNDLED` flags to tell Arrow to download and build these dependencies itself during the contrib build. Dependencies already provided by contrib (zlib, bzip2, boost) continue to be found via `CMAKE_PREFIX_PATH`.

**Note:** This requires internet access during the contrib build for the bundled dependency downloads.

Fixes OpenMS/OpenMS#8797

## Test plan

- [ ] Verify contrib CI passes on all platforms (Linux, macOS, Windows)
- [ ] Test building Arrow from contrib on a clean Debian 12 system without Snappy/zstd/Thrift installed
- [ ] Verify OpenMS builds and Parquet tests pass with the updated contrib


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed system package dependencies from installation workflows for Linux and macOS.
  * Updated build configuration to use bundled versions of Arrow dependencies (Snappy, zstd, Thrift, xsimd, RapidJSON) across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->