### PR TITLE
build: add libcurl-dev to Dockerfiles

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get -y update \
     zlib1g-dev \
     libxerces-c-dev \
     libbz2-dev \
+    libcurl4-openssl-dev \
     libomp-dev \
     libhdf5-dev\
     libboost-date-time1.74-dev \


### PR DESCRIPTION
OpenMS core library now uses libcurl instead of Qt Network for HTTP operations. Add the development packages so the build can find curl headers and libraries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies to support the build environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->