### PR TITLE
Add multi-arch manifest for contrib_manylinux_2_34 images

### DIFF
--- a/.github/workflows/deploy-manylinux-docker.yml
+++ b/.github/workflows/deploy-manylinux-docker.yml
@@ -13,6 +13,8 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64]
+    outputs:
+      tag_name: ${{ steps.tag_name.outputs.tag }}
     steps:
       - name: Extract branch name
         shell: bash
@@ -25,7 +27,7 @@ jobs:
             BRANCH=${{ steps.extract_branch.outputs.branch }}
             ## use latest to follow docker conventions
             if [[ "$BRANCH" == "master" ]]
-            then 
+            then
               BRANCH="latest"
             fi
             ## Remove release/ from release branch name
@@ -60,9 +62,28 @@ jobs:
           push: true
           file: ${{ env.dockerfile }}
           context: .
-          platforms: ${{ env.docker_platform }}          
+          platforms: ${{ env.docker_platform }}
           build-args: |
             OPENMS_BRANCH=${{ steps.extract_branch.outputs.branch }}
             OPENMS_VERSION=${{ steps.tag_name.outputs.tag }}
           tags: |
             ghcr.io/openms/contrib_manylinux_2_34:${{ steps.tag_name.outputs.tag }}-${{ env.platform_tag }}
+
+  create-multiarch-manifest:
+    needs: Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            -t ghcr.io/openms/contrib_manylinux_2_34:${{ needs.Deploy.outputs.tag_name }} \
+            ghcr.io/openms/contrib_manylinux_2_34:${{ needs.Deploy.outputs.tag_name }}-amd64 \
+            ghcr.io/openms/contrib_manylinux_2_34:${{ needs.Deploy.outputs.tag_name }}-arm64


### PR DESCRIPTION
## Summary
- After building and pushing per-arch images (`latest-amd64`, `latest-arm64`), adds a `create-multiarch-manifest` job that combines them into a single multi-arch manifest under the base tag (e.g. `latest`)
- Docker then automatically pulls the correct architecture, enabling devcontainer arm64 support

## Context
Required by OpenMS/OpenMS#8862 / OpenMS/OpenMS#8740 — the devcontainer references `ghcr.io/openms/contrib_manylinux_2_34:latest` and relies on it being a multi-arch manifest.

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` and verify the `latest` tag becomes a multi-arch manifest (`docker manifest inspect ghcr.io/openms/contrib_manylinux_2_34:latest` should show a manifest list)
- [ ] Verify devcontainer works on both amd64 and arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced deployment pipeline to automatically generate and publish multi-architecture Docker images, improving compatibility across different processor architectures and enabling deployment to diverse environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->