### PR TITLE
set minimum cmake, so arrow builds successfully

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,8 +130,8 @@ endif()
 # quick manual for most commands: https://cmake.org/cmake/help/v3.3/manual/cmake-commands.7.html
 # useful predefined variables: http://www.paraview.org/Wiki/CMake_Useful_Variables
 
-# force cmake > 3.10 to force enable c++20 support
-cmake_minimum_required(VERSION 3.10.0 FATAL_ERROR)
+# force cmake > 3.26 for Apache Arrow
+cmake_minimum_required(VERSION 3.26 FATAL_ERROR)
 
 PROJECT("OpenMS_CONTRIB")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,8 +477,6 @@ if(APPLE)
     message(STATUS "${OSX_SYSROOT_FLAG}")
   endif()
 
-  # force cmake > 3.10 to force enable c++20 support
-cmake_minimum_required(VERSION 3.10.0 FATAL_ERROR)
 endif()
 
 ## include extract/patch/build macros


### PR DESCRIPTION
otherwise you get this when building arrow from contrib:

...
-- Looking for _ _SIZEOF_INT128__
-- Looking for _ _SIZEOF_INT128__ - found
-- Found Boost: /usr/lib/x86_64-linux-gnu/cmake/Boost-1.74.0/BoostConfig.cmake (found suitable version "1.74.0", minimum required is "1.69")
-- Boost include dir: /usr/include
-- Building snappy from source
-- Found OpenSSL: /usr/lib/x86_64-linux-gnu/libcrypto.so (found suitable version "3.0.19", minimum required is "1.0.2")
-- Providing CMake module for FindOpenSSLAlt as part of Arrow CMake package
-- Found OpenSSL Crypto Library: /usr/lib/x86_64-linux-gnu/libcrypto.so
-- Building with OpenSSL (Version: 3.0.19) support
-- Thrift: Building from source
-- Configuring incomplete, errors occurred!
See also "/buffer/ag_bsc/pmsb_openms_contrib/contrib_build2026/src/arrow-apache-arrow-23.0.0/cpp/CMakeFiles/CMakeOutput.log".
See also "/buffer/ag_bsc/pmsb_openms_contrib/contrib_build2026/src/arrow-apache-arrow-23.0.0/cpp/CMakeFiles/CMakeError.log".

-- Error: Schwerwiegend: Kein Git-Repository (oder irgendein Elternverzeichnis bis zum Einhängepunkt /buffer)
Stoppe bei Dateisystemgrenze (GIT_DISCOVERY_ACROSS_FILESYSTEM nicht gesetzt).
CMake Error at cmake_modules/ThirdpartyToolchain.cmake:1748 (message):
  **Require CMake 3.26 or later for building bundled Apache Thrift**
Call Stack (most recent call first):
  cmake_modules/ThirdpartyToolchain.cmake:219 (build_thrift)
  cmake_modules/ThirdpartyToolchain.cmake:308 (build_dependency)
  cmake_modules/ThirdpartyToolchain.cmake:1849 (resolve_dependency)
  CMakeLists.txt:537 (include)



CMake Error at libraries.cmake/arrow.cmake:194 (message):
  Arrow configuration failed.  Check the log file for details:
  /buffer/ag_bsc/pmsb_openms_contrib/contrib_build2026/contrib_build.log
Call Stack (most recent call first):
  CMakeLists.txt:568 (OPENMS_CONTRIB_BUILD_ARROW)


-- Configuring incomplete, errors occurred!
See also "/buffer/ag_bsc/pmsb_openms_contrib/contrib_build2026/CMakeFiles/CMakeOutput.log".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum CMake requirement to version 3.26 (builds will fail on earlier versions).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->